### PR TITLE
CP-22756: Simplify script execution

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @cloudzero/stratus
+*       @cloudzero/stratus @cloudzero/documentation

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ source venv/bin/activate
 Install the required dependency, which is the Python [requests](https://requests.readthedocs.io/en/latest/) module:
 
 ```bash
-pip install -r requirements.txt
+pip install requests
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -120,12 +120,18 @@ python anycost_example.py --usage <path_to_usage_csv> --commitments <path_to_com
 ### Arguments
 
 - `--usage`: Path to the CSV file containing usage data. This file should include columns like `cost`, `discount`, `sku`, `instance_id`, and `usage_date`.
-- `--commitments`: Path to the CSV file containing purchase commitments data. This file should include columns like `commitment_id`, `commitment_date`, and `cost`.
-- `--discounts`: Path to the CSV file containing discounts data. This file should include columns like `discount_type`, `discount_id`, `usage_date`, and `discount`.
-- `--output`: Path to the output CSV file where transformed CBF data will be saved.
+- `--commitments` (Optional): Path to the CSV file containing purchase commitments data. This file should include columns like `commitment_id`, `commitment_date`, and `cost`.
+- `--discounts` (Optional): Path to the CSV file containing discounts data. This file should include columns like `discount_type`, `discount_id`, `usage_date`, and `discount`.
+- `--output` (Default: `cbf_output.csv`): Path to the output CSV file where transformed CBF data will be saved.
 
 ### Example
 
+The minimum parameter set is `--usage`. With only `--usage` specified, the script will process the usage data, skip discounts and purchase commitments, and save it to an output file called `cbf_output.csv` in the current working directory.
+```bash
+python anycost_example.py --usage example_cloud_provider_data/cloud_usage.csv --commitments example_cloud_provider_data/cloud_purchase_commitments.csv --discounts example_cloud_provider_data/cloud_discounts.csv --output cbf/cloud_cbf.csv
+```
+
+With `--commitments`, `--discounts`, and `--output` specified, the script will process all three data types and save the output to the file specified in `--output`.
 ```bash
 python anycost_example.py --usage example_cloud_provider_data/cloud_usage.csv --commitments example_cloud_provider_data/cloud_purchase_commitments.csv --discounts example_cloud_provider_data/cloud_discounts.csv --output cbf/cloud_cbf.csv
 ```

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ python anycost_example.py --usage <path_to_usage_csv> --commitments <path_to_com
 
 ### Example
 
-The minimum parameter set is `--usage`. With only `--usage` specified, the script will process the usage data, skip discounts and purchase commitments, and save it to an output file called `cbf_output.csv` in the current working directory.
+The minimum parameter set is `--usage`. With only `--usage` specified, the script will process the usage data, skip discounts and purchase commitments, and save the CBF to an output file called `cbf_output.csv` in the current working directory.
 ```bash
-python anycost_example.py --usage example_cloud_provider_data/cloud_usage.csv --commitments example_cloud_provider_data/cloud_purchase_commitments.csv --discounts example_cloud_provider_data/cloud_discounts.csv --output cbf/cloud_cbf.csv
+python anycost_example.py --usage example_cloud_provider_data/cloud_usage.csv
 ```
 
 With `--commitments`, `--discounts`, and `--output` specified, the script will process all three data types and save the output to the file specified in `--output`.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ python anycost_example.py --usage <path_to_usage_csv> --commitments <path_to_com
 - `--usage`: Path to the CSV file containing usage data. This file should include columns like `cost`, `discount`, `sku`, `instance_id`, and `usage_date`.
 - `--commitments` (Optional): Path to the CSV file containing purchase commitments data. This file should include columns like `commitment_id`, `commitment_date`, and `cost`.
 - `--discounts` (Optional): Path to the CSV file containing discounts data. This file should include columns like `discount_type`, `discount_id`, `usage_date`, and `discount`.
-- `--output` (Default: `cbf_output.csv`): Path to the output CSV file where transformed CBF data will be saved.
+- `--output` (Optional): Path to the output CSV file where transformed CBF data will be saved. Defaults to `cbf_output.csv`
 
 ### Example
 

--- a/anycost_example.py
+++ b/anycost_example.py
@@ -110,15 +110,19 @@ def upload_to_anycost(cbf_rows: list[dict[str, str]]):
 def main():
     parser = argparse.ArgumentParser(description="Process and upload cloud billing data.")
     parser.add_argument("--usage", required=True, help="Path to the usage data CSV file.")
-    parser.add_argument("--commitments", required=True, help="Path to the purchase commitments CSV file.")
-    parser.add_argument("--discounts", required=True, help="Path to the discounts CSV file.")
+    parser.add_argument("--commitments", help="Path to the purchase commitments CSV file.")
+    parser.add_argument("--discounts", help="Path to the discounts CSV file.")
     parser.add_argument("--output", required=True, help="Path to the output CBF CSV file.")
     args = parser.parse_args()
 
     cbf_rows = []
     cbf_rows.extend(process_usage_data(args.usage))
-    cbf_rows.extend(process_purchase_commitments(args.commitments))
-    cbf_rows.extend(process_discounts(args.discounts))
+    
+    if args.commitments:
+        cbf_rows.extend(process_purchase_commitments(args.commitments))
+    
+    if args.discounts:
+        cbf_rows.extend(process_discounts(args.discounts))
 
     write_cbf_rows_to_csv(cbf_rows, args.output)
 

--- a/anycost_example.py
+++ b/anycost_example.py
@@ -112,7 +112,7 @@ def main():
     parser.add_argument("--usage", required=True, help="Path to the usage data CSV file.")
     parser.add_argument("--commitments", help="Path to the purchase commitments CSV file.")
     parser.add_argument("--discounts", help="Path to the discounts CSV file.")
-    parser.add_argument("--output", required=True, help="Path to the output CBF CSV file.")
+    parser.add_argument("--output", default="cbf_output.csv", help="Path to the output CBF CSV file. (default: cbf_output.csv)")
     args = parser.parse_args()
 
     cbf_rows = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-requests
-


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [CloudZero Code of Conduct](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/cloudzero/template-cloudzero-open-source/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Given our aim this script a little more usable outside the context of this repository, I removed the requirements.txt file in favor of advising a direct installation of the requests module. I also relaxed the requirements a bit so that a user only needs to specify at most one file path for input data. They'll still be able to specify all four parameters if they wish, but it is no longer required.

### Testing

I used the latest python docker image, installed requests as we explain, and validated that the script successfully wrote out the expected CBF line items given the input data.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`